### PR TITLE
feat: Create scoped container that inherit a parent container's registrations

### DIFF
--- a/kiwi/lib/src/kiwi_container.dart
+++ b/kiwi/lib/src/kiwi_container.dart
@@ -8,8 +8,11 @@ typedef T Factory<T>(KiwiContainer container);
 /// A simple service container.
 class KiwiContainer {
   /// Creates a scoped container.
-  KiwiContainer.scoped()
-      : _namedProviders = Map<String?, Map<Type, _Provider<Object>>>();
+  KiwiContainer.scoped([KiwiContainer? parent])
+      : _namedProviders = parent == null
+            ? Map<String?, Map<Type, _Provider<Object>>>()
+            : parent._namedProviders
+                .map((key, value) => MapEntry(key, {...value}));
 
   static final KiwiContainer _instance = KiwiContainer.scoped();
 


### PR DESCRIPTION
Hi,

I am proposing this PR to add the only feature I am missing from Kiwi. It is the need to create a scoped container, but one that reuses all the parent's registrations. The idea is to emulate the feature I used in Unity in the past, http://unitycontainer.org/api/Unity.IUnityContainer.html#Unity_IUnityContainer_CreateChildContainer, but keeping Kiwi's existing API as unchanged as possible. 

The core of the PR is the scoped constructor, to which I added an optional parent parameter. When given a parent, the constructor will create a new _nameProviders map, which is essentially a deep clone of the parent's map:

```dart
  KiwiContainer.scoped([KiwiContainer? parent])
      : _namedProviders = parent == null
            ? Map<String?, Map<Type, _Provider<Object>>>()
            : parent._namedProviders
                .map((key, value) => MapEntry(key, {...value}));

```
The idea is for the scoped container to be a fork of the parent's registrations. After construction, all further modifications to the parent are not propagated to the scoped container. No modification to the scoped container should have an impact on the parent container. I added tests to check those behaviours.

Thank you for considering this PR.

Kind Regards,

Rui