### PR TITLE
Update referenced build_runner version

### DIFF
--- a/kiwi_generator/README.md
+++ b/kiwi_generator/README.md
@@ -21,7 +21,7 @@ The latest version is [![Pub](https://img.shields.io/pub/v/kiwi_generator.svg)](
 
 ```yaml
 dev_dependencies:  
-  build_runner: ^1.10.0
+  build_runner: ^2.2.0
   kiwi_generator: ^latest_version
 ```
 


### PR DESCRIPTION
The current documentation for the generator package leads to errors when installing the packages.

This PR updates the Readme to reference build_runner 2 which installs just fine.