### PR TITLE
feature(scoped-parent): implemented optional named parameter called parent to reuse its providers in the new instance.

### DIFF
--- a/kiwi/lib/src/kiwi_container.dart
+++ b/kiwi/lib/src/kiwi_container.dart
@@ -8,8 +8,19 @@ typedef T Factory<T>(KiwiContainer container);
 /// A simple service container.
 class KiwiContainer {
   /// Creates a scoped container.
-  KiwiContainer.scoped()
-      : _namedProviders = Map<String?, Map<Type, _Provider<Object>>>();
+  ///
+  /// If [parent] is set, the new scoped instance will include its providers.
+  KiwiContainer.scoped({
+    KiwiContainer? parent,
+  }) : _namedProviders = <String?, Map<Type, _Provider<Object>>>{
+          if (parent != null)
+            ...parent._namedProviders.map(
+              // [Map.from] is needed to create a copy of value and not use its reference,
+              // because if only value is passed, everything included in the parent will be
+              // added to the new instance at any time, even after this scoped instance has been created.
+              (key, value) => MapEntry(key, Map.from(value)),
+            ),
+        };
 
   static final KiwiContainer _instance = KiwiContainer.scoped();
 


### PR DESCRIPTION
# Description
- The purpose of this PR is to continue what @ruicraveiro did in implementing hierarchy from a parent in a `KiwiContainer.scoped`.

- #81

# What has changed?
- Since the repository has changed ownership, it was necessary to set the correct home page in kiwi pubspec.
- Used map literal `<K, V>{}` instead of `Map<K, V>()` which is deprecated in the Dart documentation.
- Now it is possible to pass a parent to a `KiwiContainer.scoped` and reuse its previously defined providers.