### PR TITLE
fix(kiwi-generator): update referenced build_runner version, using codebase from @geisterfurz007.

### DIFF
--- a/kiwi_generator/README.md
+++ b/kiwi_generator/README.md
@@ -21,7 +21,7 @@ The latest version is [![Pub](https://img.shields.io/pub/v/kiwi_generator.svg)](
 
 ```yaml
 dev_dependencies:  
-  build_runner: ^1.10.0
+  build_runner: ^2.3.3
   kiwi_generator: ^latest_version
 ```
 


### PR DESCRIPTION
# What has changed?
-  The version of `build_runner` in `README.md` of `kiwi_generator` has been updated to avoid errors, as indicated by @geisterfurz007 in his PR:
-  #85.