### PR TITLE
feature(is-registered): added a boolean method to indicate if a provider type or name is registered.

### DIFF
--- a/kiwi/lib/src/kiwi_container.dart
+++ b/kiwi/lib/src/kiwi_container.dart
@@ -155,7 +155,8 @@ class KiwiContainer {
   /// If an instance or builder of type [T] is registered with a name,
   /// and the name is not passed to [isRegistered], returns false.
   bool isRegistered<T>({String? name}) {
-    return (_namedProviders.containsKey(name) && _namedProviders[name]!.containsKey(T));
+    return (_namedProviders.containsKey(name) &&
+        _namedProviders[name]!.containsKey(T));
   }
 
   void _setProvider<T>(String? name, _Provider<T> provider) {

--- a/kiwi/lib/src/kiwi_container.dart
+++ b/kiwi/lib/src/kiwi_container.dart
@@ -150,11 +150,16 @@ class KiwiContainer {
     _namedProviders.clear();
   }
 
+  /// Returns if an instance or builder of type [T] is registered.
+  ///
+  /// If an instance or builder of type [T] is registered with a name,
+  /// and the name is not passed to [isRegistered], returns false.
+  bool isRegistered<T>({String? name}) {
+    return (_namedProviders.containsKey(name) && _namedProviders[name]!.containsKey(T));
+  }
+
   void _setProvider<T>(String? name, _Provider<T> provider) {
-    final nameProviders = _namedProviders;
-    if (!silent &&
-        (nameProviders.containsKey(name) &&
-            nameProviders[name]!.containsKey(T))) {
+    if (!silent && isRegistered<T>(name: name)) {
       throw KiwiError(
           'The type `$T` was already registered${name == null ? '' : ' for the name `$name`'}');
     }

--- a/kiwi/test/kiwi_test.dart
+++ b/kiwi/test/kiwi_test.dart
@@ -393,6 +393,49 @@ void main() {
             'Not Registered KiwiError:\n\n\nFailed to resolve `int`:\n\nThe type `int` was not registered\n\nMake sure `int` is added to your KiwiContainer and rerun build_runner build\n(If you are using the kiwi_generator)\n\nWhen using Flutter, most of the time a hot restart is required to setup the KiwiContainer again.\n\n\n',
           )));
     });
+
+    test('checks that the instances are registered', () {
+      final scoped = KiwiContainer.scoped();
+
+      // Unnamed instances
+      expect(scoped.isRegistered<int>(), false);
+
+      scoped.registerInstance<int>(5);
+
+      expect(scoped.isRegistered<int>(), true);
+      expect(scoped.resolve<int>(), 5);
+
+      scoped.unregister<int>();
+
+      expect(scoped.isRegistered<int>(), false);
+      expect(
+          () => container.resolve<int>(),
+          throwsA(TypeMatcher<KiwiError>().having(
+            (f) => f.toString(),
+            'toString()',
+            'Not Registered KiwiError:\n\n\nFailed to resolve `int`:\n\nThe type `int` was not registered\n\nMake sure `int` is added to your KiwiContainer and rerun build_runner build\n(If you are using the kiwi_generator)\n\nWhen using Flutter, most of the time a hot restart is required to setup the KiwiContainer again.\n\n\n',
+          )));
+
+      // Named instances
+      expect(scoped.isRegistered<String>(name: 'named_string_instance'), false);
+
+      scoped.registerInstance<String>('random_string', name: 'named_string_instance');
+
+      expect(scoped.isRegistered<String>(), false); // [isRegistered] cannot be true if String it is named and is tested unnamed.
+      expect(scoped.isRegistered<String>(name: 'named_string_instance'), true);
+      expect(scoped.resolve<String>('named_string_instance'), 'random_string');
+
+      scoped.unregister<String>('named_string_instance');
+
+      expect(scoped.isRegistered<String>(), false);
+      expect(
+          () => container.resolve<String>(),
+          throwsA(TypeMatcher<KiwiError>().having(
+            (f) => f.toString(),
+            'toString()',
+            'Not Registered KiwiError:\n\n\nFailed to resolve `String`:\n\nThe type `String` was not registered\n\nMake sure `String` is added to your KiwiContainer and rerun build_runner build\n(If you are using the kiwi_generator)\n\nWhen using Flutter, most of the time a hot restart is required to setup the KiwiContainer again.\n\n\n',
+          )));
+    });
   });
 }
 

--- a/kiwi/test/kiwi_test.dart
+++ b/kiwi/test/kiwi_test.dart
@@ -419,9 +419,11 @@ void main() {
       // Named instances
       expect(scoped.isRegistered<String>(name: 'named_string_instance'), false);
 
-      scoped.registerInstance<String>('random_string', name: 'named_string_instance');
+      scoped.registerInstance<String>('random_string',
+          name: 'named_string_instance');
 
-      expect(scoped.isRegistered<String>(), false); // [isRegistered] cannot be true if String it is named and is tested unnamed.
+      expect(scoped.isRegistered<String>(),
+          false); // [isRegistered] cannot be true if String it is named and is tested unnamed.
       expect(scoped.isRegistered<String>(name: 'named_string_instance'), true);
       expect(scoped.resolve<String>('named_string_instance'), 'random_string');
 


### PR DESCRIPTION
# Description
- It was not possible to check whether a type `T` of instance or builder was registered in the kiwi global or scoped providers. This limited the ability to register instances only if they were not registered.

# What has changed?
- It is now possible to check if a provider is registered by its type and/or name. 
  - Since previously there couldn't be two instances with the same registered type unless the second one had a `name`, it's safe to create this method that uses what was in `_setProvider`.
 
![image](https://github.com/vanlooverenkoen/kiwi/assets/69699209/8bfce570-fcf0-488f-adec-0493120ba42a)

- As mentioned in the comment of method, if an instance is defined with a `name` and you use the `isRegistered` method and do not pass its `name`, false will be returned if no instance was created with a `name`.

- Since what was checked within `_setProvider` was reused, it was changed to use the `isRegistered` method to avoid unnecessary code repetition.

- All 21 tests are passed correctly.