### PR TITLE
fix(typedef): fixed Factory typedef to follow the rules regarding the syntax of generic functions in typedef.

### DIFF
--- a/kiwi/lib/src/kiwi_container.dart
+++ b/kiwi/lib/src/kiwi_container.dart
@@ -3,7 +3,7 @@ import 'package:kiwi/src/model/exception/not_registered_error.dart';
 import 'package:meta/meta.dart';
 
 /// Signature for a builder which creates an object of type [T].
-typedef T Factory<T>(KiwiContainer container);
+typedef Factory<T> = T Function(KiwiContainer container);
 
 /// A simple service container.
 class KiwiContainer {


### PR DESCRIPTION
# Description
As stated in pub.dev, kiwi's score is affected by a typedef problem, which Dart describes as the misnaming of generic functions.

![image](https://github.com/vanlooverenkoen/kiwi/assets/69699209/6f1fabca-7af0-432b-89ea-a6056cd88e37)

# What has changed?

- Fixed Factory typedef to match the new way of creating typedefs in Dart.

The new code: 
![image](https://github.com/vanlooverenkoen/kiwi/assets/69699209/5eb4f776-37b5-4e5f-8067-e712fd7c9a12)

- All 21 tests are passed correctly.